### PR TITLE
feat: jwt refreshtoken 구현 및 redis 저장 [#6]

### DIFF
--- a/src/main/java/hello/booktown/config/SecurityConfig.java
+++ b/src/main/java/hello/booktown/config/SecurityConfig.java
@@ -2,11 +2,13 @@ package hello.booktown.config;
 
 import hello.booktown.jwt.JwtAuthenticationFilter;
 import hello.booktown.oauth.CustomOAuth2UserService;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -37,6 +39,9 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(unauthorizedHandler()) // 👈 추가
+                )
                 .oauth2Login(oauth -> oauth
                         .defaultSuccessUrl("/login/success", true)
                         .userInfoEndpoint(userInfo -> userInfo
@@ -46,6 +51,16 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    // 👇 인증 실패 시 JSON 응답 주는 핸들러
+    @Bean
+    public AuthenticationEntryPoint unauthorizedHandler() {
+        return (request, response, authException) -> {
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("{ \"error\": \"인증이 필요합니다.\" }");
+        };
     }
 
     @Bean

--- a/src/main/java/hello/booktown/controller/TokenController.java
+++ b/src/main/java/hello/booktown/controller/TokenController.java
@@ -1,0 +1,52 @@
+package hello.booktown.controller;
+
+import hello.booktown.jwt.JwtTokenProvider;
+import hello.booktown.service.RefreshTokenService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/token")
+public class TokenController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    public TokenController(JwtTokenProvider jwtTokenProvider, RefreshTokenService refreshTokenService) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.refreshTokenService = refreshTokenService;
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissueAccessToken(@RequestHeader("Refresh-Token") String refreshToken) {
+
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            return ResponseEntity.status(401).body("유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        String username = jwtTokenProvider.getUsernameFromToken(refreshToken);
+
+        return refreshTokenService.getRefreshToken(username)
+                .filter(savedToken -> savedToken.equals(refreshToken))
+                .map(token -> {
+                    String newAccessToken = jwtTokenProvider.generateToken(username);
+                    String newRefreshToken = jwtTokenProvider.generateRefreshToken(username);
+
+                    refreshTokenService.saveRefreshToken(
+                            username,
+                            newRefreshToken,
+                            jwtTokenProvider.getRefreshTokenRemainingMillis(newRefreshToken)
+                    );
+
+                    return ResponseEntity.ok(Map.of(
+                            "accessToken", "Bearer " + newAccessToken,
+                            "refreshToken", "Bearer " + newRefreshToken
+                    ));
+                })
+                .orElseGet(() -> ResponseEntity.status(401).body(Map.of(
+                        "error", "리프레시 토큰 정보가 존재하지 않습니다."
+                )));
+    }
+}

--- a/src/main/java/hello/booktown/controller/UserController.java
+++ b/src/main/java/hello/booktown/controller/UserController.java
@@ -2,16 +2,21 @@ package hello.booktown.controller;
 
 import hello.booktown.dto.UserLoginRequest;
 import hello.booktown.jwt.JwtTokenProvider;
+import hello.booktown.service.RefreshTokenService;
 import hello.booktown.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 @Tag(name = "User API", description = "회원가입 / 로그인 / 회원정보 관련 API")
@@ -22,13 +27,16 @@ public class UserController {
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
     private final StringRedisTemplate redisTemplate;
+    private final RefreshTokenService refreshTokenService;
 
-    public UserController(UserService userService, JwtTokenProvider jwtTokenProvider, StringRedisTemplate redisTemplate) {
+    public UserController(UserService userService, JwtTokenProvider jwtTokenProvider,
+                          StringRedisTemplate redisTemplate,
+                          RefreshTokenService refreshTokenService) {
         this.userService = userService;
         this.jwtTokenProvider = jwtTokenProvider;
         this.redisTemplate = redisTemplate;
+        this.refreshTokenService = refreshTokenService;
     }
-
 
     @Operation(summary = "회원가입", description = "사용자 정보를 받아 회원가입을 수행합니다.")
     @ApiResponse(responseCode = "200", description = "회원가입 성공")
@@ -44,13 +52,32 @@ public class UserController {
             @ApiResponse(responseCode = "401", description = "아이디 또는 비밀번호 오류")
     })
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody UserLoginRequest request) {
+    public ResponseEntity<?> login(@RequestBody UserLoginRequest request, HttpServletResponse response) {
         return userService.login(request.getUsername(), request.getPassword())
                 .map(user -> {
-                    String token = jwtTokenProvider.generateToken(user.getUsername());
-                    return ResponseEntity.ok().body(token);
+                    String accessToken = jwtTokenProvider.generateToken(user.getUsername());
+                    String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUsername());
+
+                    refreshTokenService.saveRefreshToken(
+                            user.getUsername(),
+                            refreshToken,
+                            jwtTokenProvider.getRefreshTokenRemainingMillis(refreshToken)
+                    );
+
+                    // HttpOnly 쿠키 설정
+                    Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
+                    refreshCookie.setHttpOnly(true);
+                    refreshCookie.setPath("/");
+                    refreshCookie.setMaxAge(7 * 24 * 60 * 60);
+                    response.addCookie(refreshCookie);
+
+                    return ResponseEntity.ok(Map.of(
+                            "grantType", "Bearer",
+                            "accessToken", accessToken,
+                            "refreshToken", "httpOnly"
+                    ));
                 })
-                .orElseGet(() -> ResponseEntity.status(401).body("아이디 또는 비밀번호가 틀렸습니다."));
+                .orElseGet(() -> ResponseEntity.status(401).body(Map.of("error", "아이디 또는 비밀번호가 틀렸습니다.")));
     }
 
     @Operation(summary = "내 정보 확인", description = "현재 로그인한 사용자의 정보를 확인합니다.")
@@ -69,6 +96,8 @@ public class UserController {
             long expiration = jwtTokenProvider.getExpiration(token);
             redisTemplate.opsForValue().set(token, "logout", expiration, TimeUnit.MILLISECONDS);
         }
+
+        refreshTokenService.deleteRefreshToken(username);
 
         return ResponseEntity.ok("회원 탈퇴 및 로그아웃 완료");
     }

--- a/src/main/java/hello/booktown/domain/RefreshToken.java
+++ b/src/main/java/hello/booktown/domain/RefreshToken.java
@@ -1,0 +1,29 @@
+package hello.booktown.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class RefreshToken {
+
+    public RefreshToken(String username, String token) {
+        this.username = username;
+        this.token = token;
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    @Column(nullable = false)
+    private String token;
+
+    public void updateToken(String newToken) {
+        this.token = newToken;
+    }
+}

--- a/src/main/java/hello/booktown/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/hello/booktown/jwt/JwtAuthenticationFilter.java
@@ -42,16 +42,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             String token = authHeader.substring(7);
 
-            if (jwtTokenProvider.validateToken(token) &&
-                    !Boolean.TRUE.equals(redisTemplate.hasKey(token))) {
+            if (jwtTokenProvider.validateToken(token)) {
+                String isBlacklisted = redisTemplate.opsForValue().get(token);
+                // 블랙리스트 등록된 토큰이라면 필터 진행 X
+                if (!"logout".equals(isBlacklisted)) {
+                    String username = jwtTokenProvider.getUsernameFromToken(token);
 
-                String username = jwtTokenProvider.getUsernameFromToken(token);
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(username, null, Collections.emptyList());
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(username, null, Collections.emptyList());
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
             }
         }
 

--- a/src/main/java/hello/booktown/jwt/JwtTokenProvider.java
+++ b/src/main/java/hello/booktown/jwt/JwtTokenProvider.java
@@ -19,11 +19,18 @@ public class JwtTokenProvider {
     @Value("${jwt.expiration}")
     private long expirationTime;
 
+    @Value("${jwt.refresh-expiration}")
+    private long refreshExpirationTime;
+
     private Key key;
 
     @PostConstruct
     public void init() {
         this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    public long getRefreshTokenRemainingMillis(String token) {
+        return getExpiration(token);
     }
 
     public String generateToken(String username) {
@@ -73,4 +80,15 @@ public class JwtTokenProvider {
                 .getExpiration()
                 .getTime() - System.currentTimeMillis();
     }
+
+    public String generateRefreshToken(String username) {
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshExpirationTime)) // 예: 7일
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+
 }

--- a/src/main/java/hello/booktown/repository/RefreshTokenRepository.java
+++ b/src/main/java/hello/booktown/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package hello.booktown.repository;
+
+import hello.booktown.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUsername(String username);
+}

--- a/src/main/java/hello/booktown/service/RefreshTokenService.java
+++ b/src/main/java/hello/booktown/service/RefreshTokenService.java
@@ -1,0 +1,33 @@
+package hello.booktown.service;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class RefreshTokenService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public RefreshTokenService(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    // 리프레시 토큰 저장 (만료 시간 설정 필수)
+    public void saveRefreshToken(String username, String refreshToken, long expirationMillis) {
+        redisTemplate.opsForValue().set("refresh:" + username, refreshToken, expirationMillis, TimeUnit.MILLISECONDS);
+    }
+
+    // 리프레시 토큰 조회
+    public Optional<String> getRefreshToken(String username) {
+        String token = redisTemplate.opsForValue().get("refresh:" + username);
+        return Optional.ofNullable(token);
+    }
+
+    // 리프레시 토큰 삭제
+    public void deleteRefreshToken(String username) {
+        redisTemplate.delete("refresh:" + username);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: prod
+    active: local
 
   jpa:
     properties:
@@ -31,4 +31,4 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
   expiration: 3600000
-
+  refresh-expiration: 604800000


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#6

## 📝 작업 내용
- 로그아웃 시 Refresh Token도 Redis에 저장하여 재사용 방지
- Access Token 블랙리스트 등록 로직과 함께 처리